### PR TITLE
Explicit DNS fail

### DIFF
--- a/portal/lib/troubleshooting.lua
+++ b/portal/lib/troubleshooting.lua
@@ -215,10 +215,42 @@ end
 
 function support.has_access_to_portal()
   if not cst.PortalUrl then
+    nixio.syslog('warn','Cannot find a portal url')
     return false
   end
+  
+  -- fixme
+  -- cron does not order the call so this is called before overall internet check
+  -- 
+  local file_exists = os.execute('/usr/bin/test -e /tmp/internet')
+  if file_exists == 0 then
+    nixio.syslog('warn','Cannot find /tmp/internet file in has_portal !')
+    -- no hard fail
+  end
+  local ping_ok = os.execute('/bin/ping -w 3 -c 1 8.8.8.8') then
+    nixio.syslog('warn','Cannot find 8.8.8.8 with icmp !')
+      -- no hard fail
+  end
+  
+  local domain = cst.PortalUrl:match('^%w+://([^:/]+)')
+  local proto = cst.PortalUrl:match('^(%w+)://')
+  local port = 80
+  if proto == 'https' then
+    port = 443
+  end
+  port = PortalUrl:match('^%w+://[^:/]+:(%d+)') or port
+
+  local dns_result = nixio.getaddrinfo(domain,'inet')
+  if not dns_result then
+    nixio.syslog('err','Failed to resolve portal: '..cst.PortalUrl..' as fqdn '..domain)
+    return false
+  end
+
+  local ip_portal = dns_result[1].address
+  
   local cmd = '/usr/bin/curl '
-            ..'--retry 1 --retry-delay 2 '
+            ..'--retry 3 --retry-delay 5 '
+            ..'--resolve "'..domain..':'..port..':'..ip..'" '
             ..'-w %%{http_code} '
             ..'-G '
             ..'--data-urlencode "digilan-token-action=version" '


### PR DESCRIPTION
separate DNS and Request to get proper log on failure

```
BusyBox v1.25.1 () multi-call binary.

Usage: ping [OPTIONS] HOST

Send ICMP ECHO_REQUEST packets to network hosts

        -4,-6           Force IP or IPv6 name resolution
        -c CNT          Send only CNT pings
        -s SIZE         Send SIZE data bytes in packets (default:56)
        -t TTL          Set TTL
        -I IFACE/IP     Use interface or IP address as source
        -W SEC          Seconds to wait for the first response (default:10)
                        (after all -c CNT packets are sent)
        -w SEC          Seconds until ping exits (default:infinite)
                        (can exit earlier with -c CNT)
        -q              Quiet, only display output at start
                        and when finished
        -p              Pattern to use for payload
[1]-[root@LEDE]-[~]# ping -w 3 -c 1 8.8.8.8
PING 8.8.8.8 (8.8.8.8): 56 data bytes
64 bytes from 8.8.8.8: seq=0 ttl=115 time=9.600 ms

--- 8.8.8.8 ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 9.600/9.600/9.600 ms
[0]-[root@LEDE]-[~]# ping -w 3 -c 1 224.0.0.1
PING 224.0.0.1 (224.0.0.1): 56 data bytes

--- 224.0.0.1 ping statistics ---
3 packets transmitted, 0 packets received, 100% packet loss
[1]-[root@LEDE]-[~]
```